### PR TITLE
replace wierd syntax with clear expression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,23 +31,23 @@ jobs:
         include:
         - name: Node.js 0.10
           node-version: "0.10"
-          npm-i: mocha@3.5.3 supertest@2.0.0
+          npm-i: minimatch@3.0.4 mocha@3.5.3 supertest@2.0.0
 
         - name: Node.js 0.12
           node-version: "0.12"
-          npm-i: mocha@3.5.3 supertest@2.0.0
+          npm-i: minimatch@3.0.4 mocha@3.5.3 supertest@2.0.0
 
         - name: io.js 1.x
           node-version: "1.8"
-          npm-i: mocha@3.5.3 supertest@2.0.0
+          npm-i: minimatch@3.0.4 mocha@3.5.3 supertest@2.0.0
 
         - name: io.js 2.x
           node-version: "2.5"
-          npm-i: mocha@3.5.3 supertest@2.0.0
+          npm-i: minimatch@3.0.4 mocha@3.5.3 supertest@2.0.0
 
         - name: io.js 3.x
           node-version: "3.3"
-          npm-i: mocha@3.5.3 supertest@2.0.0
+          npm-i: minimatch@3.0.4 mocha@3.5.3 supertest@2.0.0
 
         - name: Node.js 4.x
           node-version: "4.9"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,6 +37,11 @@ install:
         %{ npm rm --silent --save-dev $_ }
   # Setup Node.js version-specific dependencies
   - ps: |
+      # minimatch for Node.js < 4
+      if ([int]$env:nodejs_version.split(".")[0] -lt 4) {
+        npm install --silent --save-dev minimatch@3.0.4
+      }
+  - ps: |
       # mocha for testing
       # - use 3.x for Node.js < 4
       # - use 5.x for Node.js < 6

--- a/examples/web-service/index.js
+++ b/examples/web-service/index.js
@@ -34,7 +34,7 @@ app.use('/api', function(req, res, next){
   if (!key) return next(error(400, 'api key required'));
 
   // key is invalid
-  if (!~apiKeys.indexOf(key)) return next(error(401, 'invalid api key'));
+  if (apiKeys.indexOf(key) === -1) return next(error(401, 'invalid api key'))
 
   // all good, store req.key for route access
   req.key = key;


### PR DESCRIPTION
The use of `!~` hides the completely understandable `apiKeys.indexOf(key) < 0` or `if(!apiKeys.includes(key))`.
Since this is example code, this should be crisp and clean. 
I don't see any advantage or improvement in the use of a "bitwise negation of -1 is 0 and thus falsy, so I can use a boolean not on it for my if statement" to replace a straight "result is less than 0". I even would consider it is slower than a simple compare, since it's two operations. The newer API (includes) is even more literate in coding style. 
I suggest this is fixed.